### PR TITLE
Add support for GitHub Enterprise Server 

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -8,6 +8,10 @@ inputs:
     required: true
     default: ${{ github.token }}
 
+  baseUrl:
+    description: 'The base api url to be used in enterprise github instances'
+    required: false
+    default: "https://api.github.com"
   repository:
     description: 'The name of the repository.'
     required: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -3,6 +3,7 @@ async function run() {
   try {
     // Fetch all the inputs
     const token = core.getInput('token');
+    const url = core.getInput('baseUrl');
     const repository = core.getInput('repository');
     const retain_days = Number(core.getInput('retain_days'));
     const keep_minimum_runs = Number(core.getInput('keep_minimum_runs'));
@@ -17,7 +18,7 @@ async function run() {
     const repo_owner = splitRepository[0];
     const repo_name = splitRepository[1];
     const { Octokit } = require("@octokit/rest");
-    const octokit = new Octokit({ auth: token });
+    const octokit = new Octokit({ auth: token, baseUrl: url });
     let workflows = await octokit
       .paginate("GET /repos/:owner/:repo/actions/workflows", {
         owner: repo_owner,


### PR DESCRIPTION
In order to use the plugin on an GitHub Enterprise Server, the plugin must be enhanced to use the base url of the enterprise github server api. See [here](https://github.com/octokit/octokit.js/blob/main/README.md#constructor-options) for the oktokit constructor option.