### PR TITLE
Correct workflow run by conclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The GitHub action to delete workflow runs in a repository. This action (written 
 The action will calculate the number of days that each workflow run has been retained so far, then use this number to compare with the number you specify for the input parameter "[**`retain_days`**](#3-retain_days)". If the retention days of the workflow run has reached (equal to or greater than) the specified number, the workflow run will be deleted.
 
 ## What's new?
-* Add the input parameter "[**`delete_workflow_by_conclusion_pattern`**](#7-delete_workflow_by_conclusion_pattern)" - useful for `skipped` workflow runs.
+* Add the input parameter "[**`delete_run_by_conclusion_pattern`**](#7-delete_run_by_conclusion_pattern)" - useful for `skipped` workflow runs.
 * Add the input parameter "[**`delete_workflow_by_state_pattern`**](#6-delete_workflow_by_state_pattern)" and "[**`dry_run`**](#8-dry_run)". 
 * Add ability to filter workflows by workflow filename (in addition to the name)
 * Add ability to filter workflows by state
@@ -49,7 +49,7 @@ The name or filename of the workflow. if not set then it will target all workflo
 #### Default: 'all'
 Remove workflow by state: active, deleted, disabled_fork, disabled_inactivity, disabled_manually
 
-### 7. `delete_workflow_by_conclusion_pattern`
+### 7. `delete_run_by_conclusion_pattern`
 #### Required: NO
 #### Default: 'all'
 Remove workflow by conclusion: action_required, cancelled, failure, skipped, success 
@@ -112,7 +112,7 @@ on:
           - deleted
           - disabled_inactivity
           - disabled_manually
-      delete_workflow_by_conclusion_pattern:
+      delete_run_by_conclusion_pattern:
         description: 'Remove workflow by conclusion: action_required, cancelled, failure, skipped, success'
         required: true
         default: "All"
@@ -141,7 +141,7 @@ jobs:
           keep_minimum_runs: ${{ github.event.inputs.minimum_runs }}
           delete_workflow_pattern: ${{ github.event.inputs.delete_workflow_pattern }}
           delete_workflow_by_state_pattern: ${{ github.event.inputs.delete_workflow_by_state_pattern }}
-          delete_workflow_by_conclusion_pattern: ${{ github.event.inputs.delete_workflow_by_conclusion_pattern }}
+          delete_run_by_conclusion_pattern: ${{ github.event.inputs.delete_run_by_conclusion_pattern }}
           dry_run: ${{ github.event.inputs.dry_run }}
 ```
 ##

--- a/action.yaml
+++ b/action.yaml
@@ -35,7 +35,7 @@ inputs:
     description: 'Remove workflow by state: active, deleted, disabled_fork, disabled_inactivity, disabled_manually'
     required: false
 
-  delete_workflow_by_conclusion_pattern:
+  delete_run_by_conclusion_pattern:
     description: 'Remove workflow by conclusion: action_required, cancelled, failure, skipped, success'
     required: false
 


### PR DESCRIPTION
I apologize - apparently I did not have enough coffee when I created PR #11. The code was inadequately tested and I had put the check in the wrong location. Workflows do not have a conclusion - workflow runs do.

Enhances the delete-workflow-runs action so users can filter on the conclusion. Running issue-ops (i.e. workflows that run on issue_comment) can create a numerous runs with a state: complete and a conclusion: skipped:

https://github.com/jeremylong/DependencyCheck/actions/workflows/false-positive-approvals.yml

It would be useful to be able to regularly delete the skipped workflow runs.