### PR TITLE
Update README.md with contents: read permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The action will calculate the number of days that each workflow run has been ret
 #### Required: YES
 #### Default: `${{ github.token }}`
 The token used to authenticate.
-* If the workflow runs are in the current repository where the action is running, using **`github.token`** is OK, but you must specify `permissions: actions: write` within your build job (or at a higher level) to allow the default token access to write (delete) action-related data. More details, see the [**`GITHUB_TOKEN`**](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow).
+* If the workflow runs are in the current repository where the action is running, using **`github.token`** is OK, but you must specify additional permissions within your build job (or at a higher level) to allow the default token access to read the repository contents and to write (delete) action-related data, see the examples below. More details, see the [**`GITHUB_TOKEN`**](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow).
 * If the workflow runs are in another repository, you need to use a personal access token (PAT) that must have the **`repo`** scope. More details, see "[Creating a personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token)".
 
 ### 2. `repository`
@@ -87,6 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
+      contents: read
     steps:
       - name: Delete workflow runs
         uses: Mattraks/delete-workflow-runs@v2
@@ -149,6 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
+      contents: read
     steps:
       - name: Delete workflow runs
         uses: Mattraks/delete-workflow-runs@v2


### PR DESCRIPTION
My workflow got stuck with the error `Resource not accessible by integration` which I think refers to this API call:
```
    let branches = await octokit
      .paginate("GET /repos/:owner/:repo/branches", {
        owner: repo_owner,
        repo: repo_name,
      })
```
Adding permission `contents: read` solved the issue.