### PR TITLE
Enhance branch-specific configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,33 +40,56 @@ Amount of days used to compare with the retention days of each workflow
 #### Default: 6
 Minimum runs to keep for each workflow
 
-### 5. `delete_workflow_pattern`
+### 5. `branch_specific_minimum_runs`
 #### Required: NO
-Name or filename of the workflow (if not set, all workflows are targeted)
+#### Default: false
+When set, all workflows are grouped by branch and `keep_mininum_runs` will be applied to each group individually.
 
-### 6. `delete_workflow_by_state_pattern`
+### 6. `delete_workflow_pattern`
+#### Required: NO
+Name or filename of the workflow (if not set, all workflows are targeted).  
+_Multiple values permitted as a comma-separated list, but names used should not contain comma_
+
+### 7. `delete_workflow_by_state_pattern`
 #### Required: NO
 #### Default: 'ALL'
 Filter workflows by state: active, deleted, disabled_fork, disabled_inactivity, disabled_manually  
 _Multiple state values permitted as a comma-separated list_
 
-### 7. `delete_run_by_conclusion_pattern`
+### 8. `delete_run_by_conclusion_pattern`
 #### Required: NO
 #### Default: 'ALL'
 Remove runs based on conclusion: action_required, cancelled, failure, skipped, success  
 _Multiple conclusion values permitted as a comma-separated list_
 
-### 8. `dry_run`
+### 9. `branch_filter`
+#### Required: NO
+#### Default: '[".*"]'
+This allows the action to only target workflow runs triggered by specific branches.
+
+Expected value is a JSON array of regular expressions, e.g:  
+`'["main", "release/.*", "test/.*"]'` - only workflows whose branch names match `main`, `release/...` or `test/...` will be deleted (if no other filters prevent it).
+
+### 10. `dry_run`
 #### Required: NO
 Logs simulated changes, no deletions are performed
 ##
 
-### 9. `check_branch_existence`
+### 11. `check_branch_existence`
 #### Required: NO
 If true, the removage of a workflow is skipped, when a run is attached to a existing branch. Set to true avoids that check runs are deleted and the checks are not more present. (excludes main)
+
+### 12. `check_branch_existence_exceptions`
+#### Required: NO
+#### Default: main
+Only applies when `check_branch_existence=true`.  
+The branch name(s) listed here will be exempt from the existence check. Workflows from matching branches will not be checked for existence.
+This is useful to keep the history of permanent branches tidy while still preventing temporary branches from losing all their checks.  
+_Multiple names are permitted as a comma-separated list. Contrary to branch_filter, this does not use pattern matching._
+
 ##
 
-### 10. `check_pullrequest_exist`
+### 13. `check_pullrequest_exist`
 #### Required: NO
 If true, the Runs will be checked for linkage to a PR.
 ##

--- a/action.yaml
+++ b/action.yaml
@@ -28,8 +28,15 @@ inputs:
     required: true
     default: 6
 
+  branch_specific_minimum_runs:
+    description: 'When true, the number of minimum runs is counted per branch instead of overall'
+    required: false
+    default: false
+
   delete_workflow_pattern:
-    description: 'Name or filename of the workflow (if not set, all workflows are targeted)'
+    description: |
+      Name or filename of the workflow (if not set, all workflows are targeted). Can also be a comma-separated list of file names.
+      If workflow names are used instead of file names, they should not contain commas.
     required: false
 
   delete_workflow_by_state_pattern:
@@ -44,9 +51,21 @@ inputs:
     description: 'Logs simulated changes, no deletions are performed'
     required: false
 
+  branch_filter:
+    description: |
+      Json-String containing array of 1-n branch name (regex). When active, only workflow runs triggered by a matching branch will be considered.
+      Works best with 'branch_specific_minimum_runs:true'
+    required: false
+    default: '[".*"]'
+    
   check_branch_existence:
     description: 'If the workflow was triggered by a branch, the branch must be deleted before the workflow run is deleted as well.'
     required: false
+
+  check_branch_existence_exceptions:
+    description: 'Comma separated list of branch names that shall be ignored for "check_branch_existence". These branches will have their workflows deleted, even when they still exist.'
+    required: false
+    default: main
 
   check_pullrequest_exist:
     description: "If the run is linked to a pull request, the deletion is skipped."


### PR DESCRIPTION
This commit introduces options and logic to better handle workflows running on multiple branches.

- `branch_specific_minimum_runs`: this makes the number `n` supplied by 'keep_minimum_runs' apply on a per-branch basis instead. So the effective maximum number of kept workflows would be `applicable_branches * keep_minimum_runs`. But i think this more useful than just indiscriminately taking the `n` most up-to-date runs like it is done right now. In an environment with a lot of active branches, the most frequently updated branches will keep their runs while 'slower' branches might get fully wiped all the time.
- `delete_workflow_pattern`: enhancement: allows a comma separated list of workflow files/names instead of just one name
- `check_branch_existence_exceptions`: Value is a comma-separated list. Only applies when 'check_branch_existence' is enabled. Branch names listed here will receive deletions even when they still exist. With this, permanent branches can be kept tidy while temporary branches retain their checks.
- `branch_filter`: A json list of regular expressions. When given, only workflow runs whose branch name matches any entry in the list will be considered for deletion. Depending on configuration, the runs might still be filtered out by other criteria afterwards. Useful to create jobs dedicated to house-keeping of permanent branches.