### PR TITLE
Added try/catch blocks to catch each error individually

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -62,16 +62,13 @@ async function run() {
         repo: repo_name,
       });
 
-    // Creates the delete runs array, and adds the runs that don't have a workflow associated with it
     let del_runs = new Array();
     for (const run of all_runs) {
-      if (!workflow_ids.includes(run.workflow_id)) {
+      // Creates the delete runs array, and adds the runs that don't have a workflow associated with it
+      // if (!workflow_ids.includes(run.workflow_id)) { -> Deleted this condition. It doesn't make sense.
         del_runs.push(run);
         core.debug(`  Added to del list '${run.name}' workflow run ${run.id}`);
-      }
-      else {
-        core.debug(`  Skipped '${run.name}' workflow run ${run.id}`);
-      }    
+      // }
     }
 
     console.log(`💬 found total of ${del_runs.length} workflow run(s)`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -82,11 +82,16 @@ async function run() {
         continue;
       }
 
-      await octokit.actions.deleteWorkflowRun({
-        owner: repo_owner,
-        repo: repo_name,
-        run_id: del.id
-      });
+      try {
+        await octokit.actions.deleteWorkflowRun({
+          owner: repo_owner,
+          repo: repo_name,
+          run_id: del.id
+        });
+      }
+      catch (error) {
+        core.setFailed(error.message);
+      }
 
       console.log(`🚀 Delete run ${del.id} of '${del.name}' workflow`);
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -186,11 +186,16 @@ async function run() {
             continue;
           }
 
-          await octokit.actions.deleteWorkflowRun({
-            owner: repo_owner,
-            repo: repo_name,
-            run_id: del.id
-          });
+          try {
+            await octokit.actions.deleteWorkflowRun({
+              owner: repo_owner,
+              repo: repo_name,
+              run_id: del.id
+            });
+          }
+          catch (error) {
+            core.setFailed(error.message);
+          }
 
           console.log(`🚀 Delete run ${del.id} of '${workflow.name}' workflow`);
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -52,10 +52,6 @@ async function run() {
         repo: repo_name,
       });
 
-    if (dry_run) {
-        console.log('[dry-run] Workflows', workflows);
-    }
-
     let workflow_ids = workflows.map(w => w.id);
 
     // Gets all workflow runs for the repository
@@ -73,6 +69,9 @@ async function run() {
         del_runs.push(run);
         core.debug(`  Added to del list '${run.name}' workflow run ${run.id}`);
       }
+      else {
+        core.debug(`  Skipped '${run.name}' workflow run ${run.id}`);
+      }    
     }
 
     console.log(`💬 found total of ${del_runs.length} workflow run(s)`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -52,6 +52,10 @@ async function run() {
         repo: repo_name,
       });
 
+    if (dry_run) {
+        console.log('[dry-run] Workflows', workflows);
+    }
+
     let workflow_ids = workflows.map(w => w.id);
 
     // Gets all workflow runs for the repository


### PR DESCRIPTION
I am facing an error during execution, which is being caught by the single try/catch block.

This is displaying a message, but it is stopping before it reaches the point where it perform the delete action.
```
💬 found total of 208 workflow run(s)
Error: Could not delete the workflow run
```

My proposal is to add try/catch blocks before each API call.