### PR TITLE
Upgrade to Node 24

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -53,5 +53,5 @@ branding:
   icon: "trash"
   color: "red"
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
<img width="1429" height="304" alt="image" src="https://github.com/user-attachments/assets/3ebee3a3-41cc-422a-9b5a-d02b311395b4" />
This PR should remove this warning.